### PR TITLE
feat(tls_config): disable TLS and mTLS by default

### DIFF
--- a/internal/config/agent/tls_config.go
+++ b/internal/config/agent/tls_config.go
@@ -9,10 +9,10 @@ import (
 )
 
 type TlsConfig struct {
-	Enabled              bool   `default:"true" negatable:"true" help:"Enable Tls"`
+	Enabled              bool   `default:"false" help:"Enable Tls"`
 	ClientTrustedCaCerts string `validate:"omitempty,file" help:"Path to the client trusted ca certs"`
 
-	MTLSEnabled bool   `name:"mtls-enabled" default:"false" negatable:"true" help:"Enable mutual tls" group:"grpc-mtls"`
+	MTLSEnabled bool   `name:"mtls-enabled" default:"false" help:"Enable mutual tls" group:"grpc-mtls"`
 	ClientCert  string `validate:"required_if=MTLSEnabled true,omitempty,file" help:"Path to the client tls cert" group:"grpc-mtls"`
 	ClientKey   string `validate:"required_if=MTLSEnabled true,omitempty,file" help:"Path to the client tls key" group:"grpc-mtls"`
 }

--- a/internal/config/server/tls_config.go
+++ b/internal/config/server/tls_config.go
@@ -9,11 +9,11 @@ import (
 )
 
 type TlsConfig struct {
-	Enabled    bool   `default:"true" negatable:"true" help:"Enable Tls"`
+	Enabled    bool   `default:"false" help:"Enable Tls"`
 	ServerCert string `validate:"required_if=Enabled true,omitempty,file" help:"Path to the server tls cert"`
 	ServerKey  string `validate:"required_if=Enabled true,omitempty,file" help:"Path to the server tls key"`
 
-	MTLSEnabled         bool   `name:"mtls-enabled" negatable:"true" help:"Enable mutual tls"`
+	MTLSEnabled         bool   `name:"mtls-enabled" default:"false" help:"Enable mutual tls"`
 	TrustedCA           string `name:"trusted-ca" validate:"required_if=MTLSEnabled true,omitempty,file" help:"Path to the server trusted ca certs"`
 	TrustedClientDomain string `validate:"omitempty,fqdn"`
 }


### PR DESCRIPTION
The default values for `Enabled` and `MTLSEnabled` in the `TlsConfig` struct have been changed from `true` to `false`. This means that both TLS and mutual TLS (mTLS) are now disabled by default. Users who wish to enable these features will need to explicitly set these values to `true` in their configuration.