### PR TITLE
feat(grpc_config): trim auth token

### DIFF
--- a/internal/config/agent/grpc_config.go
+++ b/internal/config/agent/grpc_config.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"os"
+	"strings"
 )
 
 type GrpcClientConfig struct {
@@ -18,5 +19,5 @@ func (g *GrpcClientConfig) AuthToken() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(token), nil
+	return strings.TrimSpace(string(token)), nil
 }

--- a/internal/config/agent/grpc_config_test.go
+++ b/internal/config/agent/grpc_config_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrpcClientConfig_AuthToken(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	// Write a test token to the file
+	testToken := "test-token \n"
+	if _, err := io.WriteString(tempFile, testToken); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a GrpcClientConfig with the temporary file as the AuthTokenFile
+	config := &GrpcClientConfig{
+		AuthTokenFile: tempFile.Name(),
+	}
+
+	// Call AuthToken and check the returned token
+	token, err := config.AuthToken()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-token", token)
+}


### PR DESCRIPTION
The AuthToken method in the GrpcClientConfig struct now trims the authentication token read from the AuthTokenFile. This change ensures that any leading or trailing whitespace in the token file does not affect the token's usage. A unit test has been added to verify this behavior.