### PR TITLE
chore(grpc_config): change temp file prefix

### DIFF
--- a/internal/config/agent/grpc_config_test.go
+++ b/internal/config/agent/grpc_config_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGrpcClientConfig_AuthToken(t *testing.T) {
 	// Create a temporary file
-	tempFile, err := os.CreateTemp("", "test")
+	tempFile, err := os.CreateTemp("", "pg_helper_test-grpc_config")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The temporary file prefix in the grpc_config_test has been changed from "test" to "pg_helper_test-grpc_config" to provide more context about the test that is creating the temporary file.