### PR TITLE
feat(job_handler): Improve error handling and logging

### DIFF
--- a/internal/job/job_handler.go
+++ b/internal/job/job_handler.go
@@ -79,7 +79,7 @@ func (h *JobHandler) addJob(job Job) error {
 
 	if _, ok := h.jobs[job.UUID()]; ok {
 		err := ErrJobAlreadyExist
-		log.Warn().Err(err).
+		log.Debug().Err(err).
 			Str("JobName", job.GetName()).
 			Msg("Nothing to do")
 		return logger.NewAlreadyLoggedError(err, zerolog.WarnLevel)
@@ -106,11 +106,14 @@ func (h *JobHandler) processTask(task Task) error {
 		err = ErrNotSupportedTaskStatus
 	}
 
-	log.Warn().Err(err).
-		Str("JobID", task.JobID().String()).
-		Str("TaskName", task.GetName()).
-		Msg("Nothing to do")
-	return logger.NewAlreadyLoggedError(err, zerolog.WarnLevel)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("JobID", task.JobID().String()).
+			Str("TaskName", task.GetName()).
+			Msg("Nothing to do")
+		return logger.NewAlreadyLoggedError(err, zerolog.WarnLevel)
+	}
+	return nil
 }
 
 func (h *JobHandler) processDoneTask(task Task) error {


### PR DESCRIPTION
This commit improves the error handling in the job_handler module. Previously, the log level for an existing job was set to Warn, which has been changed to Debug. This will reduce unnecessary warning logs for jobs that already exist.

In the processTask function, the error handling has been improved. Previously, a warning was logged and an error returned regardless of whether an error occurred. Now, the warning is only logged and the error returned if an actual error occurs. If no error occurs, the function now correctly returns nil.